### PR TITLE
Update version file URL property

### DIFF
--- a/GameData/000_Harmony/Harmony.version
+++ b/GameData/000_Harmony/Harmony.version
@@ -1,7 +1,7 @@
 {
   "NAME": "Harmony",
-  "URL": "https://raw.githubusercontent.com/HarmonyKSP/HarmonyKSP/main/GameData/000_Harmony/Harmony.version",
-  "DOWNLOAD": "https://github.com/HarmonyKSP/HarmonyKSP/releases",
+  "URL": "https://raw.githubusercontent.com/KSPModdingLibs/HarmonyKSP/main/GameData/000_Harmony/Harmony.version",
+  "DOWNLOAD": "https://github.com/KSPModdingLibs/HarmonyKSP/releases",
   "VERSION": {"MAJOR": 2, "MINOR": 0, "PATCH": 4, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},


### PR DESCRIPTION
Hi @gotmachine, GitHub's API doesn't like serving up redirects; it seems to count them as taking up extra API calls somehow.
Now the URLs in this version file are current.