### PR TITLE
Update version file to include compatibility with KSP 1.12

### DIFF
--- a/GameData/000_Harmony/Harmony.version
+++ b/GameData/000_Harmony/Harmony.version
@@ -5,5 +5,5 @@
   "VERSION": {"MAJOR": 2, "MINOR": 0, "PATCH": 4, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
-  "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 11, "PATCH": 99}
+  "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 99}
 }


### PR DESCRIPTION
Hey @gotmachine, do you think we could mark HarmonyKSP as compatible with KSP 1.12?
I did spend some time playing with LMP on KSP 1.12, and from what I can tell it appears to work just fine.
But of course, as author it's your call.

If you think it's fine, I've taken some work off your hands, and prepared the update to the version file in this PR.
Thanks to the remote version file feature, CKAN (and AVC) will fetch the new data automatically, no new release required.